### PR TITLE
SCSS adapter improperly named

### DIFF
--- a/lib/adapters/scss.coffee
+++ b/lib/adapters/scss.coffee
@@ -3,7 +3,7 @@ W          = require 'when'
 path       = require 'path'
 
 class SCSS extends Adapter
-  name: 'css'
+  name: 'scss'
   extensions: ['scss']
   output: 'css'
   supportedEngines: ['node-sass']


### PR DESCRIPTION
It's currently named as "CSS", which means you have to pass `node-sass` options to "css" and not "scss". This fixes that.