### PR TITLE
Add less imports to reponse object

### DIFF
--- a/lib/adapters/less.coffee
+++ b/lib/adapters/less.coffee
@@ -19,7 +19,7 @@ class Less extends Adapter
 
     @engine.render str, options, (err, res) ->
       if err then return deferred.reject(err)
-      obj = { result: res.css }
+      obj = { result: res.css, imports: res.import }
       if options.sourceMap and res.map
         obj.sourcemap = JSON.parse(res.map)
         sourcemaps.inline_sources(obj.sourcemap).then (map) ->


### PR DESCRIPTION
Acording to https://github.com/less/less-docs/blob/master/content/usage/programmatic-usage.md the less compiler outputs a list of imported dependencies in the output. These should also be available in Accord for dependency tracking