### PR TITLE
Add node-sass 1.x 2.x and 3.x compatibility in scss adapter. Fixes #86

### DIFF
--- a/lib/adapter_base.coffee
+++ b/lib/adapter_base.coffee
@@ -152,12 +152,17 @@ class Adapter
 
 requireEngine = (engineName, customPath) ->
   if customPath?
-    engine = require(resolve.sync(path.basename(customPath), basedir: customPath))
+    modulePath = resolve.sync(path.basename(customPath), basedir: customPath)
+    engine = require(modulePath)
     engine.__accord_path = customPath
+    try
+      engine.version = require(modulePath + '/package.json').version
+    catch err
   else
     try
       engine = require(engineName)
       engine.__accord_path = resolvePath(engineName)
+      engine.version = require(engineName + '/package.json').version
     catch err
       throw new Error("'#{engineName}' not found. make sure it has been installed!")
   return engine

--- a/lib/adapters/scss.coffee
+++ b/lib/adapters/scss.coffee
@@ -1,6 +1,7 @@
 Adapter    = require '../adapter_base'
 W          = require 'when'
 path       = require 'path'
+semver     = require 'semver'
 
 class SCSS extends Adapter
   name: 'scss'

--- a/lib/adapters/scss.coffee
+++ b/lib/adapters/scss.coffee
@@ -12,55 +12,92 @@ class SCSS extends Adapter
   _render: (str, options) ->
     deferred = W.defer()
 
-    if options.sourcemap is true
-      options.sourceMap = true
-      options.outFile = path.basename(options.filename).replace('.scss', '.css')
-      options.omitSourceMapUrl = true
-      options.sourceMapContents = true
+    if semver.satisfies(@engine.version, '0.x || 1.x')
+      options.file = options.filename
+      options.data = str
 
-    options.file = options.filename
-    options.data = str
+      stats = {}
 
-    # node-sass 1.x needs this
-    stats = {}
-    options.stats = stats
-
-    successHandler = (res) ->
-      # node-sass 1.x compatibility
-      if typeof res == 'string'
-        res = {
-          css: res,
-          stats: stats
-          map: stats.sourceMap
+      options.error = (err) -> deferred.reject(err)
+      options.success = (res) ->
+        data = {
+          result: String(res),
+          imports: stats.includedFiles,
+          meta: {
+            entry: stats.entry,
+            start: stats.start,
+            end: stats.end,
+            duration: stats.duration
+          }
         }
 
-      data = {
-        result: String(res.css),
-        imports: res.stats.includedFiles,
-        meta: {
-          entry: res.stats.entry,
-          start: res.stats.start,
-          end: res.stats.end,
-          duration: res.stats.duration
+        deferred.resolve(data)
+
+      @engine.render options
+
+    else if semver.satisfies(@engine.version, '2.x')
+      if options.sourcemap is true
+        options.sourceMap = true
+        options.outFile = path.basename(options.filename).replace('.scss', '.css')
+        options.omitSourceMapUrl = true
+        options.sourceMapContents = true
+
+      options.file = options.filename
+      options.data = str
+
+      options.error = (err) -> deferred.reject(err)
+      options.success = (res) ->
+        data = {
+          result: String(res.css),
+          imports: res.stats.includedFiles,
+          meta: {
+            entry: res.stats.entry,
+            start: res.stats.start,
+            end: res.stats.end,
+            duration: res.stats.duration
+          }
         }
-      }
 
-      if res.map and Object.keys(JSON.parse(res.map)).length
-        data.sourcemap = JSON.parse(res.map)
-        data.sourcemap.sources.pop()
-        data.sourcemap.sources.push(options.file)
+        if res.map and Object.keys(JSON.parse(res.map)).length
+          data.sourcemap = JSON.parse(res.map)
+          data.sourcemap.sources.pop()
+          data.sourcemap.sources.push(options.file)
 
-      deferred.resolve(data)
+        deferred.resolve(data)
 
-    # node-sass 2.x needs handlers in options
-    options.error = (err) -> deferred.reject(err)
-    options.success = successHandler
+      @engine.render options
 
-    # node-sass 3.x needs handlers as 2nd argument
-    @engine.render options, (err, res) ->
-      if err then return deferred.reject(err)
+    else
+      if options.sourcemap is true
+        options.sourceMap = true
+        options.outFile = path.basename(options.filename).replace('.scss', '.css')
+        options.omitSourceMapUrl = true
+        options.sourceMapContents = true
 
-      successHandler(res)
+      options.file = options.filename
+      options.data = str
+
+      @engine.render options, (err, res) ->
+        if err then return deferred.reject(result: res)
+
+        data = {
+          result: String(res.css),
+          imports: res.stats.includedFiles,
+          meta: {
+            entry: res.stats.entry,
+            start: res.stats.start,
+            end: res.stats.end,
+            duration: res.stats.duration
+          }
+        }
+
+        if res.map and Object.keys(JSON.parse(res.map)).length
+          data.sourcemap = JSON.parse(res.map)
+          data.sourcemap.sources.pop()
+          data.sourcemap.sources.push(options.file)
+
+        deferred.resolve(data)
+
 
     return deferred.promise
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "indx": "0.2.x",
     "lodash": "3.x",
     "resolve": "1.x",
-    "semver": "^4.3.3",
+    "semver": "4.x",
     "uglify-js": "2.x",
     "when": "3.x"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "indx": "0.2.x",
     "lodash": "3.x",
     "resolve": "1.x",
+    "semver": "^4.3.3",
     "uglify-js": "2.x",
     "when": "3.x"
   },

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -5,6 +5,7 @@ _      = require 'lodash'
 accord = require '../'
 fs     = require 'fs'
 should = chai.should()
+semver = require 'semver'
 
 require('./helpers')(should)
 
@@ -20,11 +21,23 @@ describe 'base functions', ->
     (-> accord.load('jade')).should.not.throw()
     (-> accord.load('blargh')).should.throw()
 
+  it 'load should return engine version', ->
+    adapter = accord.load('jade')
+    semver.valid(adapter.engine.version).should.be.ok
+
   it 'load should accept a custom path', ->
     (-> accord.load('jade', path.join(__dirname, '../node_modules/jade'))).should.not.throw()
 
+  it 'load should return engine version when loading with custom path', ->
+    adapter = accord.load('jade', path.join(__dirname, '../node_modules/jade'))
+    semver.valid(adapter.engine.version).should.be.ok
+
   it "load should resolve a custom path using require's algorithm", ->
     (-> accord.load('jade', path.join(__dirname, '../node_modules/jade/missing/path'))).should.not.throw()
+
+  it "load should return engine version when resolving a custom path using require's algorithm", ->
+    adapter = accord.load('jade', path.join(__dirname, '../node_modules/jade'))
+    semver.valid(adapter.engine.version).should.be.ok
 
   it 'all should return all adapters', ->
     accord.all().should.be.a('object')


### PR DESCRIPTION
This makes the scss adapter compatible between node-sass 1.x 2.x and 3.x.

Tested with 3.0.0-pre, 2.0.1 and 1.2.3

I couldn't get 1.2.3 sourcemaps to work, but this is at least better than the state it was in before