### PR TITLE
Call coffee compiler directly from node_modules in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 build:
 	cp -R lib src
-	coffee -c lib
+	./node_modules/coffee-script/bin/coffee -c lib
 	find lib -iname "*.coffee" -exec rm '{}' ';'
 
 unbuild:


### PR DESCRIPTION
Noticed the Makefile didn't work for me because of an implicit global dependency