### PR TITLE
update babel test for latest version's output

### DIFF
--- a/test/fixtures/babel/expected/basic.js
+++ b/test/fixtures/babel/expected/basic.js
@@ -1,12 +1,14 @@
 'use strict';
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _get = function get(object, property, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { desc = parent = getter = undefined; _again = false; var object = _x,
+    property = _x2,
+    receiver = _x3; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
-var _inherits = function (subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
 var Test = (function (_TestClass) {
   function Test(greeting) {

--- a/test/fixtures/babel/expected/string.js
+++ b/test/fixtures/babel/expected/string.js
@@ -1,3 +1,3 @@
-"use strict";
+'use strict';
 
-console.log("foo");
+console.log('foo');

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1072,8 +1072,9 @@ describe 'babel', ->
     @babel.name.should.be.ok
 
   it 'should render a string', (done) ->
+    p = path.join(@path, 'string.jsx')
     @babel.render("console.log('foo');").catch(should.not.exist)
-      .done((res) => should.match_expected(@babel, res.result, path.join(@path, 'string.jsx'), done))
+      .done((res) => should.match_expected(@babel, res.result, p, done))
 
   it 'should render a file', (done) ->
     lpath = path.join(@path, 'basic.jsx')
@@ -1083,7 +1084,8 @@ describe 'babel', ->
 
   it 'should not be able to compile', (done) ->
     @babel.compile()
-      .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
+      .done(((r) -> should.not.exist(r); done()), ((r) ->
+        should.exist(r); done()))
 
   it 'should correctly handle errors', (done) ->
     @babel.render("!   ---@#$$@%#$")


### PR DESCRIPTION
- the expected output has changed with the new version of babel which was causing the tests to fail. 
- the babel transpiler was slurping (technical term) the `\n`'s at the EOF and was causing the expected match to fail. 