### PR TITLE
Node sass evergreen

### DIFF
--- a/lib/adapters/scss.coffee
+++ b/lib/adapters/scss.coffee
@@ -6,7 +6,7 @@ class SCSS extends Adapter
   name: 'scss'
   extensions: ['scss', 'sass']
   output: 'css'
-  supportedEngines: ['node-sass']
+  supportedEngines: ['node-sass-evergreen']
 
   _render: (str, options) ->
     deferred = W.defer()

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "glob": "5.x",
     "indx": "0.2.x",
     "lodash": "3.x",
+    "node-sass-evergreen": "^1.0.0",
     "resolve": "1.x",
     "uglify-js": "2.x",
     "when": "3.x"


### PR DESCRIPTION
Use node-sass-evergreen to provide the latest node-sass API to accord but keep backwards compatibility with older node-sass versions

Fixes #86
Closes #87 