### PR TITLE
Add jade2php adapter, no tests

### DIFF
--- a/lib/adapters/jade2php.coffee
+++ b/lib/adapters/jade2php.coffee
@@ -1,0 +1,22 @@
+Adapter    = require '../adapter_base'
+convert    = require 'convert-source-map'
+W          = require 'when'
+_          = require 'lodash'
+
+class JadePHP extends Adapter
+  name: 'jade2php'
+  extensions: ['jade']
+  output: 'php'
+  _compile: (str, options) ->
+    phpDefaultOptions =
+        omitPhpExtractor: yes
+        omitPhpRuntime: yes
+    compile => (@engine str, _.merge(phpDefaultOptions,options))
+
+
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(result: -> res)
+
+module.exports = JadePHP

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "html-minifier": "latest",
     "istanbul": "0.3.x",
     "jade": "latest",
+    "jade2php": "latest",
     "less": "latest",
     "LiveScript": "latest",
     "marc": "latest",


### PR DESCRIPTION
I created this jade2php adapter but I'm not really sure if it meets the requirements or the adapter interface. The compile function returns an object similar to the jade adapter compile function. Could you check this out?