### PR TITLE
Reverse expected and result comparison order to correct failed test diff

### DIFF
--- a/test/helpers.coffee
+++ b/test/helpers.coffee
@@ -17,5 +17,5 @@ module.exports = (should) ->
     fs.existsSync(expected_path).should.be.ok
     expected = parser(fs.readFileSync(expected_path, 'utf8'))
     results = parser(content)
-    util.inspect(expected).should.eql(util.inspect(results), "expected output doesn't match")
+    util.inspect(results).should.eql(util.inspect(expected), "expected output doesn't match")
     done()


### PR DESCRIPTION
It was really difficult understanding what the problems in failing tests was because the order of comparison was reversed. The diff was inverted