### PR TITLE
match_version_to_adapter: Also strip off a .js extension

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -77,6 +77,6 @@ get_version = (engine_path) ->
 match_version_to_adapter = (name, version) ->
   adapters = fs.readdirSync(path.join(__dirname, 'adapters', name))
   for adapter in adapters
-    adapter = adapter.replace(/.coffee$/, '')
+    adapter = adapter.replace(/\.(?:js|coffee)$/, '')
     if semver.satisfies(version, adapter)
       return path.join(__dirname, 'adapters', name, adapter)


### PR DESCRIPTION
 to support the case where the code is compiled to JavaScript.

Previously accord.load would break with "<moduleName> version x.y.z is not currently supported".