### PR TITLE
switch from extends to defaults for compileFile

### DIFF
--- a/lib/adapter_base.coffee
+++ b/lib/adapter_base.coffee
@@ -118,7 +118,7 @@ class Adapter
   compileFile: (file, opts = {}) ->
     (new File(file))
       .read(encoding: 'utf8')
-      .then _.partialRight(@compile, _.extend({ filename: file }, opts)).bind(@)
+      .then _.partialRight(@compile, _.defaults({ filename: file }, opts)).bind(@)
 
   ###*
    * Compile a string to a client-side-ready function


### PR DESCRIPTION
- fixes issue within roots-contentful (and likely other extensions where the `filename` attribute was being wrongfully overwritten on subsequent compiles