### PR TITLE
Sass entry file is the first (not last) file in sources array

### DIFF
--- a/lib/adapters/scss/3.x.coffee
+++ b/lib/adapters/scss/3.x.coffee
@@ -34,8 +34,8 @@ class SCSS extends Adapter
 
       if res.map
         data.sourcemap = JSON.parse(res.map.toString('utf8'))
-        data.sourcemap.sources.pop()
-        data.sourcemap.sources.push(options.file)
+        if data.sourcemap.sources[0]
+          data.sourcemap.sources[0] = options.file
 
       deferred.resolve(data)
 


### PR DESCRIPTION
Based on my testing with node-sass 3.4.2, the entry file is the first file in the sources array.
The previous code assumed that it was the last item.