### PR TITLE
Fix uglify-js dep. due to NSP security notification.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lodash": "3.x",
     "resolve": "1.x",
     "semver": "^4.3.4",
-    "uglify-js": "2.x",
+    "uglify-js": "^2.6.0",
     "when": "3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Addresses https://nodesecurity.io/advisories/48 by limiting uglify-js dependency to 2.6.0 and above.
Fixes #123
