### PR TITLE
Convert SCSS sourcemap source to absolute paths

### DIFF
--- a/lib/adapters/scss/3.x.coffee
+++ b/lib/adapters/scss/3.x.coffee
@@ -13,7 +13,7 @@ class SCSS extends Adapter
 
     if options.sourcemap is true
       options.sourceMap = true
-      options.outFile = path.basename(options.filename).replace('.scss', '.css')
+      options.outFile = options.filename.replace('.scss', '.css')
       options.omitSourceMapUrl = true
       options.sourceMapContents = true
 
@@ -34,8 +34,10 @@ class SCSS extends Adapter
 
       if res.map
         data.sourcemap = JSON.parse(res.map.toString('utf8'))
-        data.sourcemap.sources.pop()
-        data.sourcemap.sources.push(options.file)
+        basePath = path.dirname(options.filename)
+        data.sourcemap.sources =
+          data.sourcemap.sources.map (relativePath) ->
+            path.join(basePath, relativePath)
 
       deferred.resolve(data)
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -889,6 +889,19 @@ describe 'scss', ->
         res.sourcemap.sourcesContent.length.should.be.above(0)
       .done((res) => should.match_expected(@scss, res.result, lpath, done))
 
+  it 'should generate a sourcemap with correct sources', (done) ->
+    lpath = path.join(@path, 'external.scss')
+    mixinpath = path.join(@path, '_mixin_lib.scss')
+    @scss.renderFile(lpath, { sourcemap: true })
+      .tap (res) ->
+        res.sourcemap.version.should.equal(3)
+        res.sourcemap.mappings.length.should.be.above(1)
+        res.sourcemap.sources.length.should.equal(2)
+        res.sourcemap.sources[0].should.equal(lpath)
+        res.sourcemap.sources[1].should.equal(mixinpath)
+        res.sourcemap.sourcesContent.length.should.equal(2)
+      .done((res) => should.match_expected(@scss, res.result, lpath, done))
+
 describe 'less', ->
 
   before ->


### PR DESCRIPTION
This is basically #119 but without the erroneous commits.

I'm not 100% sure that `process.cwd()` is the correct way to do this, it works in my testing but perhaps there are cases or environments where it might not work?