### PR TITLE
Only allow certain keys for babel

### DIFF
--- a/lib/adapters/babel/6.x.coffee
+++ b/lib/adapters/babel/6.x.coffee
@@ -1,6 +1,7 @@
-Adapter    = require '../../adapter_base'
 path       = require 'path'
 W          = require 'when'
+_          = require 'lodash'
+Adapter    = require '../../adapter_base'
 sourcemaps = require '../../sourcemaps'
 
 class Babel extends Adapter
@@ -17,7 +18,22 @@ class Babel extends Adapter
     options.sourceFileName = filename
     delete options.sourcemap
 
-    compile => @engine.transform(str, options)
+    # Babel will crash if you pass any keys others than ones they accept in the
+    # options object. To be fair, accord should not populate the options object
+    # with potentially unused options, or even options that might cause errors
+    # as they do here. Eventually this should be fixed up. But to prevent
+    # babel-specific breakage, we sanitize the options object here in the
+    # meantime.
+
+    allowed_keys = ['filename', 'filenameRelative', 'presets', 'plugins',
+    'highlightCode', 'only', 'ignore', 'auxiliaryCommentBefore',
+    'auxiliaryCommentAfter', 'sourceMaps', 'inputSourceMap', 'sourceMapTarget',
+    'sourceMapTarget', 'sourceRoot', 'moduleRoot', 'moduleIds', 'moduleId',
+    'getModuleId', 'resolveModuleSource', 'code', 'babelrc', 'ast', 'compact',
+    'comments', 'shouldPrintComment', 'env', 'retainLines', 'extends']
+    sanitized_options = _.pick(options, allowed_keys)
+
+    compile => @engine.transform(str, sanitized_options)
 
   # private
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1267,9 +1267,15 @@ describe 'babel', ->
       res.sourcemap.should.exist
       res.sourcemap.version.should.equal(3)
       res.sourcemap.mappings.length.should.be.above(1)
-      res.sourcemap.sources[0].should.equal(lpath)
+      res.sourcemap.sources[0].should.equal('basic.js')
       res.sourcemap.sourcesContent.length.should.be.above(0)
       should.match_expected(@babel, res.result, lpath, done)
+
+  it 'should not allow keys outside of babel\'s options', (done) ->
+    lpath = path.join(@path, 'basic.js')
+    @babel.renderFile(lpath, { presets: ['es2015'], foobar: 'wow' })
+      .catch(should.not.exist)
+      .done((res) => should.match_expected(@babel, res.result, lpath, done))
 
 describe 'jsx', ->
 


### PR DESCRIPTION
So Babel will error and not compile if you pass it any keys in the options object that it does not recognize. This presents a dilemma for accord, which adds standard options to the object for general use, and for anyone else using accord who might have any options other than babel's options on the object when it's passed in.

The best fix for this would be to stop accord from adding any options beyond ones that we know are required by the compiler, for all compilers, but unfortunately this would be an obscene amount of maintenance to always be on top of all compilers' options and which ones are allowed vs not.

So the patch for now is just to remove any disallowed keys from going into the babel adapter. This is some extra maintenance, as the list would need to be updated if babel's API was changed, but it's better than the alternative, unfortunately.