### PR TITLE
Add `pcss` and `sss` file extensions

### DIFF
--- a/lib/adapters/postcss/4.x - 5.x.coffee
+++ b/lib/adapters/postcss/4.x - 5.x.coffee
@@ -7,7 +7,7 @@ convert    = require 'convert-source-map'
 
 class PostCSS extends Adapter
   name: 'postcss'
-  extensions: ['css']
+  extensions: ['css', 'pcss', 'sss']
   output: 'css'
 
   _render: (str, options) ->


### PR DESCRIPTION
Why we need `pcss`: We don't,  but a lot of users are familiar with the `pcss` file extension convention for PostCSS.
Why we need `sss`: The [SugarSS](https://github.com/postcss/sugarss) syntax has a [syntax highlight plugin](https://atom.io/packages/language-postcss-sugarss) that only recognizes this extension...